### PR TITLE
add `recursive_error_pages on` to a sample nginx config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ The views are:
         ...
 
         # this redirects to the login view when not logged in
+        recursive_error_pages on;
         error_page 401 = @error401;
         location @error401 {
             return 302 /+login;


### PR DESCRIPTION
The redirect to a login page via `error_page 401 = @error401;` might fail in configuration that does other redirects (e.g. http to https), returning the raw 401 page to client. Adding `recursive_error_pages on` fixes that.